### PR TITLE
chore: use buildx for docker build pipeline

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        id: setup_buildx
+        uses: docker/setup-buildx-action@v3
       - name: Log in to the Container registry
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567
         with:
@@ -25,7 +28,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push Docker image
         if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
-        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile
@@ -36,7 +39,7 @@ jobs:
           cache-to: type=gha,mode=max
       - name: Build and push Docker image
         if: github.event_name == 'workflow_dispatch'
-        uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
This pull request includes updates to the Docker build and push workflow in the `.github/workflows/build-push.yml` file. The changes focus on setting up Docker Buildx and updating the Docker build-push action version.

Updates to the Docker build and push workflow:

* Added a step to set up Docker Buildx using `docker/setup-buildx-action@v3`.
* Updated the Docker build-push action to use `docker/build-push-action@v6` for both push and workflow dispatch events. [[1]](diffhunk://#diff-43c93d8fb63d2b17115bf33b86f825c3ec37507c6f869bb973e31e73341107ccL28-R31) [[2]](diffhunk://#diff-43c93d8fb63d2b17115bf33b86f825c3ec37507c6f869bb973e31e73341107ccL39-R42)